### PR TITLE
Fixed errors in RNA schema

### DIFF
--- a/src/main/proto/ga4gh/rna_quantification.proto
+++ b/src/main/proto/ga4gh/rna_quantification.proto
@@ -76,10 +76,10 @@ message ExpressionLevel {
   string quantification_group_id = 3;
 
   // The number of reads mapped to this feature.
-  float32 raw_read_count = 4;
+  float raw_read_count = 4;
 
   // Numerical expression value.
-  float32 expression = 5;
+  float expression = 5;
 
   // True if the expression value is a normalized value.
   bool is_normalized = 6;
@@ -88,9 +88,9 @@ message ExpressionLevel {
   ExpressionUnit units = 7;
 
   // Weighted score for the expression value.
-  float32 score = 8;
+  float score = 8;
 
   // Confidence interval on the expression value.  Expressed as a sorted array
   // from low to high.
-  repeated float32 conf_interval = 9;
+  repeated float conf_interval = 9;
 }

--- a/src/main/proto/ga4gh/rna_quantification_service.proto
+++ b/src/main/proto/ga4gh/rna_quantification_service.proto
@@ -75,6 +75,7 @@ message SearchRnaQuantificationsResponse {
 message GetRnaQuantificationRequest {
   // The ID of the `RnaQuantification`.
   string rna_quantification_id = 1;
+}
 
 // ****************  /expressionlevel/search  *******************
 // This request maps to the body of 'POST /expressionlevel/search'
@@ -91,7 +92,7 @@ message SearchExpressionLevelsRequest {
 
   // Only return ExpressionLevel records with expressions exceeding
   // this value.  (Defaults to 0.0)
-  float32 threshold = 4;
+  float threshold = 4;
 
   // Specifies the maximum number of results to return in a single page.
   // If unspecified, a system default will be used.


### PR DESCRIPTION
- `float32` -> `float` (https://developers.google.com/protocol-buffers/docs/proto3#scalar)
- added a missing close brace.
