### PR TITLE
Removed unnecessary imports that were causing tests to fail.

### DIFF
--- a/src/main/proto/ga4gh/rna_quantification.proto
+++ b/src/main/proto/ga4gh/rna_quantification.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package ga4gh;
 
-import "ga4gh/common.proto";
-import "ga4gh/metadata.proto";
 import "google/protobuf/struct.proto";
 
 // Units for expression level.


### PR DESCRIPTION
importing `common` and `metadata` into rna was causing travis failures.
